### PR TITLE
Fix AudioNode.disconnect(node)

### DIFF
--- a/src/__tests__/api/AudioNode.js
+++ b/src/__tests__/api/AudioNode.js
@@ -126,7 +126,7 @@ describe('api/AudioNode', () => {
       expect(target._impl.connect.mock.calls[0][1]).toBe(output);
     });
 
-    it('.disconnect(...args)', () => {
+    it('.disconnect(...args) mocked', () => {
       const context = new AudioContext();
       const target = context.createGain();
       const output = 0;
@@ -136,6 +136,22 @@ describe('api/AudioNode', () => {
       target.disconnect(output);
       expect(target._impl.disconnect).toHaveBeenCalledTimes(1);
       expect(target._impl.disconnect.mock.calls[0][0]).toBe(output);
+    });
+
+    it('.disconnect(...args) real', () => {
+      const context = new AudioContext();
+      const source = context.createGain();
+      const dest = context.destination;
+
+      expect(source._impl.outputs[0].inputs).toHaveLength(0);
+
+      source.connect(dest);
+
+      expect(source._impl.outputs[0].inputs).toHaveLength(1);
+
+      source.disconnect(dest);
+
+      expect(source._impl.outputs[0].inputs).toHaveLength(0);
     });
   });
 });

--- a/src/impl/core/AudioNodeOutput.js
+++ b/src/impl/core/AudioNodeOutput.js
@@ -110,9 +110,11 @@ class AudioNodeOutput {
   disconnect(...args) {
     const isTargetToDisconnect =
       args.length === 1
-        ? (target) => target.node === args[0]
+        ? (target) => target.node === args[0] || target.node === args[0]._impl
         : args.length === 2
-        ? (target) => target.node === args[0] && target.index === args[1]
+        ? (target) =>
+            (target.node === args[0] || target.node === args[0]._impl) &&
+            target.index === args[1]
         : () => true;
 
     for (let i = this.inputs.length - 1; i >= 0; i--) {


### PR DESCRIPTION
The issue here is that `AudioNodeOutput.disconnect` is comparing the `impl.AudioNode` instance (stored internally) with `api.AudioNode` instance (passed into the disconnect method), and they're never equal. 

I'm not entirely sure if this is the _right_ fix but it works. Also added a simple unit test that failed before this change.