### PR TITLE
more readme updates and tweak when github actions are triggered

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,8 +1,9 @@
 name: Publish to NPM
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   publish-npm:

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 
 Fork of [mohayonao/web-audio-engine](https://github.com/mohayonao/web-audio-engine) with following changes:
 
-- Use TypeScript and fix some types
-  - Remove `BaseAudioContext.suspend()`
-- Add new `RawDataAudioContext`
+- Use TypeScript and fix some types ([#5](https://github.com/descriptinc/web-audio-js/pull/5))
+  - Remove `BaseAudioContext.suspend()` ([#6](https://github.com/descriptinc/web-audio-js/pull/6))
+- Add new `RawDataAudioContext` ([#5](https://github.com/descriptinc/web-audio-js/pull/5))
+- Add support for `DynamicsCompressorNode` ([#1](https://github.com/descriptinc/web-audio-js/pull/1))
 - Bug fixes
-  - Fixes for `BiquadFilterNode` and `DelayNode`
-  - Fix WAVE decoding
-  - Fix `AudioNode.disconnect(x)` not disconnecting
+  - Fixes for `BiquadFilterNode` and `DelayNode` ([#8](https://github.com/descriptinc/web-audio-js/pull/8))
+  - Fix WAVE file decoding ([#5](https://github.com/descriptinc/web-audio-js/pull/5))
+  - Fix `AudioNode.disconnect(x)` not disconnecting ([#7](https://github.com/descriptinc/web-audio-js/pull/7))
 
 ## Installation
 


### PR DESCRIPTION
- only run `Node CI` on branch pushes (not tag pushes)
- only run `Publish to NPM` on tag pushes that match `v*`

## Tested

- [x] pushed this branch, it built on NodeCI
- [x] pushed a tag "test-branch" on this branch, and it didn't build
- [x] pushed a tag "v-test-version" on this branch, it didn't build, but it tried to publish (and failed in this case because I didn't increase the version in package.json)